### PR TITLE
[iOS] Added support for iPad

### DIFF
--- a/ios/Gorilla Groove.xcodeproj/project.pbxproj
+++ b/ios/Gorilla Groove.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.gorillagroove;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -663,7 +663,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.gorillagroove;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The existing app doesn't support iPad, so you get a iPhone emulation kind of thing. While I'm home, I use my iPad (in landscape) for pretty much all media consumption. This update helps make that a much cleaner experience.

----

# OLD

https://user-images.githubusercontent.com/10839089/106369427-6f201e80-630e-11eb-9e06-d508216d11cd.mov

# NEW

https://user-images.githubusercontent.com/10839089/106369428-71827880-630e-11eb-9c65-47d1787343a8.mov